### PR TITLE
Fix package.json git repo URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "repository": {
       "type": "git",
-      "url": "http://github.com/indexzero/timespan.git" 
+      "url": "https://github.com/indexzero/TimeSpan.js.git" 
   },
   "keywords": ["time", "dates", "utilities", "timespan"],
   "devDependencies": {


### PR DESCRIPTION
The previous URL was not `git clone`able.

```
$ git clone https://github.com/indexzero/TimeSpan.js.git
Cloning into 'TimeSpan.js'...
remote: Counting objects: 127, done.
remote: Compressing objects: 100% (59/59), done.
remote: Total 127 (delta 51), reused 120 (delta 46)
Receiving objects: 100% (127/127), 39.22 KiB, done.
Resolving deltas: 100% (51/51), done.
q:~/src/sourcegraph $ git clone http://github.com/indexzero/timespan.git
Cloning into 'timespan'...
Username for 'http://github.com': ^C
```
