### PR TITLE
Factory methods now accept 0.

### DIFF
--- a/lib/time-span.js
+++ b/lib/time-span.js
@@ -778,7 +778,7 @@ TimeSpan.prototype._format = function () {
 // specified `input`.
 //
 function isNumeric (input) {
-  return input && !isNaN(parseFloat(input)) && isFinite(input);
+  return !isNaN(parseFloat(input)) && isFinite(input);
 };
 
 //

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -20,15 +20,18 @@ var helpers = exports,
 // Tests all of the factory methods for the `TimeSpan` object:
 // `fromMilliseconds`, `fromSeconds`, etc.
 //
-exports.testFactories = function (num) {
+exports.testFactories = function (nums) {
   var context = {};
   
   components.forEach(function (component) {
     var method = 'from' + capitalize(component);
-    
+
     context['the ' + method + '() method'] = function () {
-      var value = timeSpan[method](num);
-      assert.equal(value[component], num);
+
+      nums.forEach(function (num) {
+        var value = timeSpan[method](num);
+        assert.equal(value[component], num);
+      });
     }
   });
   

--- a/test/time-span-test.js
+++ b/test/time-span-test.js
@@ -63,6 +63,6 @@ vows.describe('time-span').addBatch({
         assert.equal(2, timeSpan.fromDates('NOW-4DAYS', 'NOW-2DAYS').days);
       }
     },
-    "the factory methods": helpers.testFactories(10)
+    "the factory methods": helpers.testFactories([0, 10])
   }
 }).export(module);


### PR DESCRIPTION
Previously, fromSeconds and similar methods would return `undefined` if passed `0` as input. Now they return a zero length time span.

This was caused by a check in `isNumeric`, which was counting 0 as non-numeric.

This fixes [this issue](https://github.com/indexzero/TimeSpan.js/issues/4).
