### PR TITLE
Limit digit matches to mitigate ReDoS vulnerabilities

### DIFF
--- a/lib/time-span.js
+++ b/lib/time-span.js
@@ -34,8 +34,8 @@ var msecPerSecond = 1000,
 //
 // ### Timespan Parsers
 //
-var timeSpanWithDays = /^(\d+):(\d+):(\d+):(\d+)(\.\d+)?/,
-    timeSpanNoDays = /^(\d+):(\d+):(\d+)(\.\d+)?/;
+var timeSpanWithDays = /^(\d{0,16}):(\d{0,16}):(\d{0,16}):(\d{0,16})(\.\d{0,16})?/,
+    timeSpanNoDays = /^(\d{0,16}):(\d{0,16}):(\d{0,16})(\.\d{0,16})?/;
 
 //
 // ### function TimeSpan (milliseconds, seconds, minutes, hours, days)
@@ -165,7 +165,7 @@ exports.parse = function (str) {
 //
 var parsers = {
   'milliseconds': {
-    exp: /(\d+)milli(?:second)?[s]?/i,
+    exp: /(\d{0,16})milli(?:second)?[s]?/i,
     compute: function (delta, computed) {
       return _compute(delta, computed, {
         current: 'milliseconds',
@@ -175,7 +175,7 @@ var parsers = {
     }
   },
   'seconds': {
-    exp: /(\d+)second[s]?/i,
+    exp: /(\d{0,16})second[s]?/i,
     compute: function (delta, computed) {
       return _compute(delta, computed, {
         current: 'seconds',
@@ -185,7 +185,7 @@ var parsers = {
     }
   },
   'minutes': {
-    exp: /(\d+)minute[s]?/i,
+    exp: /(\d{0,16})minute[s]?/i,
     compute: function (delta, computed) {
       return _compute(delta, computed, {
         current: 'minutes',
@@ -195,7 +195,7 @@ var parsers = {
     }
   },
   'hours': {
-    exp: /(\d+)hour[s]?/i,
+    exp: /(\d{0,16})hour[s]?/i,
     compute: function (delta, computed) {
       return _compute(delta, computed, {
         current: 'hours',
@@ -205,7 +205,7 @@ var parsers = {
     }
   },
   'days': {
-    exp: /(\d+)day[s]?/i,
+    exp: /(\d{0,16})day[s]?/i,
     compute: function (delta, computed) {
       var days     = monthDays(computed.months, computed.years),
           sign     = delta >= 0 ? 1 : -1,
@@ -249,7 +249,7 @@ var parsers = {
     }
   },
   'months': {
-    exp: /(\d+)month[s]?/i,
+    exp: /(\d{0,16})month[s]?/i,
     compute: function (delta, computed) {
       var round = delta > 0 ? Math.floor : Math.ceil;
       if (delta) { 
@@ -266,7 +266,7 @@ var parsers = {
     }
   },
   'years': {
-    exp: /(\d+)year[s]?/i,
+    exp: /(\d{0,16})year[s]?/i,
     compute: function (delta, computed) {
       if (delta) { computed.years += delta; }
       return computed;
@@ -321,7 +321,7 @@ exports.parseDate = function (str) {
   // of the target `str` to parse.
   //
   parserNames.forEach(function (group) {
-    zulu += '(\\d+[a-zA-Z]+)?';
+    zulu += '(\\d{0,16}[a-zA-Z]+)?';
   });
   
   if (/^NOW/i.test(str)) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "timespan",
   "description": "A JavaScript TimeSpan library for node.js (and soon the browser)",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": "Michael Stum <blog@stum.de>",
   "contributors": [
     { "name": "Charlie Robbins", "email": "charlie.robbins@gmail.com" }


### PR DESCRIPTION
- Replaced use of `\d+` with `\d{0,16}`

This should in theory go some way to mitigate ReDoS issues listed in #10 by limiting the number of matches to the length of the MAX_SAFE_INTEGER.